### PR TITLE
Fixed bug in Eagle Scouts admin which displayed URL in the Year Earned column.

### DIFF
--- a/wp-content/plugins/troop380/admin/class-troop380-admin.php
+++ b/wp-content/plugins/troop380/admin/class-troop380-admin.php
@@ -198,13 +198,14 @@ class Troop380_Admin {
 	 */
 	public function manage_eaglescout_posts_columns( $columns ) {
 
-		$inserted = [
-			'year_earned' => __('Year Earned', 'textdomain'), 
-			'board_of_review' => __('Board of Review', 'textdomain')
-		];
-		array_splice($columns, 2, 0, $inserted);
-	
-		return $columns;
+		$custom_columns = array(
+			'title' => 'Title',
+			'year_earned' => 'Year Earned',
+			'board_of_review' => 'Board of Review',
+			'date' => 'Date'
+		);
+
+		return $custom_columns;
 
 	}
 
@@ -215,20 +216,29 @@ class Troop380_Admin {
 	 */
 	public function manage_eaglescout_posts_custom_column( $column, $post_id ) {
 
+		$output = "";
+
 		// Populate column form meta
 		switch ( $column ) {
-			// case "year_earned":
-			case '0':
+			case "year_earned":
 				$year_earned = get_post_meta($post_id, 'year_earned', true);
-            	echo '<span>'; _e($year_earned, 'textdomain'); '</span>';
+            	$output .= '<span>'; 
+				$output .= $year_earned;
+				$output .= '</span>';
+
+				echo $output;
             	break;
 				
-			// case "board_of_review_date":
-			case '1':
+			case "board_of_review":
 				$board_of_review_date = get_post_meta($post_id, 'board_of_review_date', true);	
 				$board_of_review_date_is_real = (get_post_meta($post_id, 'board_of_review_date_is_real', true) == 'on');
 
-				echo '<span'; echo ($board_of_review_date_is_real) ? '>' : ' style="font-style: italic;">'; _e($board_of_review_date, 'textdomain'); echo '</span>';
+				$output .= '<span'; 
+				$output .= ($board_of_review_date_is_real) ? '>' : ' style="font-style: italic;">'; 
+				$output .= $board_of_review_date;
+				$output .= '</span>';
+
+				echo $output;
 				break;
 		}
 

--- a/wp-content/plugins/troop380/troop380.php
+++ b/wp-content/plugins/troop380/troop380.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Troop 380
  * Plugin URI:        https://github.com/dbuckingham/wp-troop380
  * Description:       A WP plugin of useful, scouting related features, built for Troop 380 of the Lincoln Heritage Council.
- * Version:           1.1.0
+ * Version:           1.1.1
  * Author:            David Buckingham
  * Author URI:        https://github.com/dbuckingham/wp-troop380
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TROOP380_VERSION', '1.1.0' );
+define( 'TROOP380_VERSION', '1.1.1' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
The method in which the custom columns were "spliced" into the array of standard columns, resulted in issues when the JetPack plugin tried to insert the statistics column.